### PR TITLE
Make GHA a build chore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,7 +62,7 @@ updates:
     open-pull-requests-limit: 1 # SET TO 0 TO ONLY SHOW SECURITY UPDATES
     commit-message: # USED TO TRIGGER APPROPRIATE SEMANTIC FIX COMMIT
       include: scope
-      prefix: 'fix(deps): GHA'
+      prefix: 'chore(build): GHA'
     labels: 
       - 'dependencies'
       - 'dependabot'


### PR DESCRIPTION
Changing semantic commit messages for GHA updates to be 'chore(build):' to avoid version bumps due to build process changes

[_Created by Sourcegraph batch change `Brian-Triplett/make-gha-a-chore`._](https://ncino.sourcegraphcloud.com/users/Brian-Triplett/batch-changes/make-gha-a-chore)