### PR TITLE
Shorten dependabot prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,7 +33,7 @@ updates:
     open-pull-requests-limit: 1 # SET TO 0 TO ONLY SHOW SECURITY UPDATES
     commit-message: 
       include: scope
-      prefix: 'fix(deps): NPM'
+      prefix: 'fix'
     labels: 
       - 'dependencies'
       - 'dependabot'
@@ -62,7 +62,7 @@ updates:
     open-pull-requests-limit: 1 # SET TO 0 TO ONLY SHOW SECURITY UPDATES
     commit-message: # USED TO TRIGGER APPROPRIATE SEMANTIC FIX COMMIT
       include: scope
-      prefix: 'chore(build): GHA'
+      prefix: 'chore'
     labels: 
       - 'dependencies'
       - 'dependabot'


### PR DESCRIPTION
Changing the prefix to be less verbose for dependabot PRs

[_Created by Sourcegraph batch change `Brian-Triplett/depenabot-prefix-and-scope`._](https://ncino.sourcegraphcloud.com/users/Brian-Triplett/batch-changes/depenabot-prefix-and-scope)