### PR TITLE
Feat/do 3489/cmitzel

### DIFF
--- a/workflow-templates/1gp-ci.yml
+++ b/workflow-templates/1gp-ci.yml
@@ -6,7 +6,7 @@ on:
       - '*.*.x'
 
   merge_group:
-    types: [changes_requested]
+    types: [checks_requested]
 
   workflow_dispatch:
     inputs:

--- a/workflow-templates/1gp-publish.yml
+++ b/workflow-templates/1gp-publish.yml
@@ -87,7 +87,7 @@ jobs:
           github-token: ${{ steps.app-token.outputs.token }}
           jira-user: ${{ secrets.JIRA_USER }}
           jira-token: ${{ secrets.JIRA_TOKEN }}
-          jira-base-url: 'https://ncinodev.atlassian.net'
+          jira-base-url: ${{ vars.ATLASSIAN_BASE_URL }}
 
       - name: 🪬 Transition Jira Tickets
         uses: ncino/action-jira-transition@v1

--- a/workflow-templates/1gp-publish.yml
+++ b/workflow-templates/1gp-publish.yml
@@ -287,8 +287,6 @@ jobs:
         with:
           issue-ids: ${{ needs.swordfish.outputs.jira-ticket-ids }}
           new-status: 'Verification'
-          PACKAGE_VERSION: ${{ needs.transition-to-packaging.outputs.tag }}
-          RELEASE_FULLNAME: ${{ env.RELEASE_FULLNAME }}
 
       - name: ✅🔎 Send Success QA Notifications
         uses: ncino/action-slack-notification@v1

--- a/workflow-templates/1gp-publish.yml
+++ b/workflow-templates/1gp-publish.yml
@@ -153,7 +153,7 @@ jobs:
         run: $DELIVERY_SCRIPTS_PATH/remove_unchanged_flows.py
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          PACKAGE_VERSION: ${{ needs.transition-to-packaging.outputs.tag }}
+          PACKAGE_VERSION: ${{ needs.swordfish.outputs.tag }}
 
       - name: 📦 Auth to packaging org 📦
         run: |
@@ -215,7 +215,7 @@ jobs:
 
       - name: ?🔎 Send deploy failure QA notifications
         uses: ncino/action-slack-notification@v1
-        if: always() &&  steps.deploy-package.outcome != 'success'
+        if: always() && steps.deploy-to-packaging-org.outcome != 'success'
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           slack-channel-name: ${{ env.QA_FAILURE_SLACK_CHANNEL }}

--- a/workflow-templates/1gp-publish.yml
+++ b/workflow-templates/1gp-publish.yml
@@ -35,6 +35,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      issues: write
 
   ##########################################################
   ######## 🐠⚔︎ Transition Tickets to Packaging 🐠⚔︎ #########

--- a/workflow-templates/add-to-release.properties.json
+++ b/workflow-templates/add-to-release.properties.json
@@ -1,0 +1,7 @@
+{
+  "name": "Add Version to Release",
+  "description": "Adds a version to a release.",
+  "iconName": "tag",
+  "categories": ["ci", "deployments"],
+  "filePatterns": ["release.yml$"]
+}

--- a/workflow-templates/add-to-release.yml
+++ b/workflow-templates/add-to-release.yml
@@ -1,0 +1,38 @@
+name: 🚚 Add Version to Release 🚚
+on:
+ workflow_dispatch:
+  inputs:
+   release-id:
+    description: 'Release ID'
+    type: string
+    required: false
+
+   metadata-package-version-id:
+    description: 'Metadata package version ID'
+    type: string
+    required: true
+
+ workflow_call:
+  inputs:
+   metadata-package-version-id:
+    description: 'Metadata package version ID'
+    type: string
+    required: true
+
+jobs:
+ add-package-version-to-release:
+  runs-on: ubuntu-latest
+  steps:
+   - name: Add Version to Release
+     id: add-package-version
+     uses: ncino/action-release-automation/add-package-version-to-release@v1
+     with:
+      release-id: ${{ inputs.release-id }}
+      release-type: ${{ vars.RELEASE_TYPE }}
+      metadata-package-version-id: ${{ inputs.metadata-package-version-id }}
+      spa-api-url: ${{ vars.SPA_API_URL }}
+      spa-api-key: ${{ secrets.SPA_API_KEY }}
+
+   - name: Check Output
+     run: |
+      echo "Add version to release output: ${{ steps.add-package-version.outputs.result }}"

--- a/workflow-templates/commit-lint.yml
+++ b/workflow-templates/commit-lint.yml
@@ -1,7 +1,7 @@
 name: ✓ Commit Lint
 on:
     merge_group:
-        types: [changes_requested]
+        types: [checks_requested]
 
     pull_request:
         branches:
@@ -16,18 +16,21 @@ on:
         outputs:
             release:
                 description: 'Describes the highest level of semantic commit detected'
-                value: ${ jobs.lint-commits.outputs.release }
+                value: ${{ jobs.lint-commits.outputs.release }}
 
 permissions:
     contents: read
     pull-requests: read
+    issues: write
 
 jobs:
     lint-commits:
         runs-on: ubuntu-latest
         outputs:
-            release: ${ steps.analyze-commits.outputs.release }
+            release: ${{ steps.analyze-commits.outputs.release }}
         steps:
             - name: Analyze Commits
               uses: ncino/semantic-commit-analyzer@v3
               id: analyze-commits
+              with:
+                  github-token: ${{ github.token }}

--- a/workflow-templates/hybrid-ci.yml
+++ b/workflow-templates/hybrid-ci.yml
@@ -2,7 +2,7 @@ name: Hybrid CI build
 
 on:
   merge_group:
-    types: [changes_requested]
+    types: [checks_requested]
 
   pull_request:
     branches:


### PR DESCRIPTION
Jason had a good idea where we just replace the current versions with the versions in this template repo, but messing around with it i found some issues that needed to be shored up. 

This pull request introduces a new workflow for adding a package version to a release, improves existing workflow templates by updating permissions and input handling, and makes several small corrections to workflow triggers and variable usage. The most significant changes are the addition of the `add-to-release.yml` workflow, enhancements to permissions for issue writing, and improvements to how inputs and outputs are referenced in workflows.

**New workflow addition:**

* Added a new workflow template `add-to-release.yml` and its corresponding properties file to support adding a metadata package version to a release, including required inputs and integration with the release automation action. [[1]](diffhunk://#diff-54ee35bcf9e2a11dee5836f8294e605e38f80ba5dedbb8a4e60fa31e997e8ef3R1-R38) [[2]](diffhunk://#diff-e39cbbaec93ca04ebcb971fd97ade0b7a1a0c499685846f961690f90b5a8bec7R1-R7)

**Workflow permissions and input/output improvements:**

* Updated permissions in `1gp-publish.yml` and `commit-lint.yml` to grant `issues: write` access, enabling workflows to interact with GitHub issues. [[1]](diffhunk://#diff-47c5453c8f788e138e59e77f9ea8ca7a10911931f27c842102a546a75485268eR38) [[2]](diffhunk://#diff-00792edf54091733acbd3b5bfe232ade8e20e644e2cc675977bd44e9ecf569eeL19-R36)
* Improved input/output syntax in `commit-lint.yml` to use the correct `${{ ... }}` format for referencing workflow outputs, and added the `github-token` input for the semantic commit analyzer step.

**Variable and secret usage improvements:**

* Changed the Jira base URL in `1gp-publish.yml` to use the `ATLASSIAN_BASE_URL` variable instead of a hardcoded value, improving configurability.

**Workflow trigger corrections:**

* Updated workflow triggers in `1gp-ci.yml`, `commit-lint.yml`, and `hybrid-ci.yml` to use `checks_requested` instead of `changes_requested` for `merge_group` events, aligning with current GitHub event types. [[1]](diffhunk://#diff-91bc36802f73c95624da2b6d3c2f86e2bd67f6008a91c7dd121f778da5ad4fbbL9-R9) [[2]](diffhunk://#diff-00792edf54091733acbd3b5bfe232ade8e20e644e2cc675977bd44e9ecf569eeL4-R4) [[3]](diffhunk://#diff-d43d707a175a4a7bdccf0c203e1029a2a93cc2fc8e375c5a056b1d840ab50ddcL5-R5)

**Minor cleanup:**

* Removed unused environment variables from the Jira ticket transition step in `1gp-publish.yml`.